### PR TITLE
Add script for cleaning text book corpus

### DIFF
--- a/preprocess_books.py
+++ b/preprocess_books.py
@@ -1,0 +1,50 @@
+import os
+import re
+from pathlib import Path
+
+INPUT_DIR = Path('books_txt_output')
+OUTPUT_DIR = Path('books_txt_clean')
+
+URL_PATTERN = re.compile(r'https?://\S+|www\.\S+')
+EMAIL_PATTERN = re.compile(r'\S+@\S+')
+FOOTNOTE_PATTERN = re.compile(r'\[\s*[\*\-\u2190]?\d+\s*\]')
+
+def preprocess_line(line: str) -> str:
+    line = line.strip('\ufeff').strip()  # remove BOM and surrounding spaces
+    line = URL_PATTERN.sub('', line)
+    line = EMAIL_PATTERN.sub('', line)
+    line = FOOTNOTE_PATTERN.sub('', line)
+    line = re.sub(r'\s+', ' ', line)  # collapse whitespace
+    return line.strip()
+
+def should_skip(line: str) -> bool:
+    if not line:
+        return True
+    # skip lines that contain only digits or punctuation
+    if re.fullmatch(r'[\d\W]+', line):
+        return True
+    return False
+
+def preprocess_file(in_path: Path, out_path: Path):
+    with in_path.open('r', encoding='utf-8', errors='ignore') as f:
+        lines = f.readlines()
+
+    cleaned = []
+    for line in lines:
+        line = preprocess_line(line)
+        if should_skip(line):
+            continue
+        cleaned.append(line)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open('w', encoding='utf-8') as f:
+        f.write('\n'.join(cleaned))
+
+
+def preprocess_directory(input_dir: Path = INPUT_DIR, output_dir: Path = OUTPUT_DIR):
+    for path in input_dir.glob('*.txt'):
+        out_file = output_dir / path.name
+        preprocess_file(path, out_file)
+
+if __name__ == '__main__':
+    preprocess_directory()


### PR DESCRIPTION
## Summary
- implement `preprocess_books.py` for stripping URLs, emails, and footnote markers from book text files
- script loads files from `books_txt_output` and writes cleaned versions to `books_txt_clean`

## Testing
- `python -m py_compile preprocess_books.py`


------
https://chatgpt.com/codex/tasks/task_e_686bbcd895f0832da06c0b8360173ec7